### PR TITLE
Fix: Remove markdown formatting from UseCaseForm.tsx

### DIFF
--- a/frontend/src/components/UseCaseForm.tsx
+++ b/frontend/src/components/UseCaseForm.tsx
@@ -1,4 +1,3 @@
-```tsx
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getUseCaseById, createUseCase, updateUseCase, UseCase as UseCaseType } from '../services/api'; // Renamed UseCase to UseCaseType to avoid conflict
@@ -270,4 +269,3 @@ const UseCaseForm: React.FC = () => {
 };
 
 export default UseCaseForm;
-```


### PR DESCRIPTION
The file frontend/src/components/UseCaseForm.tsx contained markdown code fences (```tsx and ```) at the beginning and end of the file. This caused parsing and compilation errors when running `npm start`.

This commit removes the extraneous markdown formatting, leaving only the valid TypeScript/JSX code. This should resolve the reported frontend compilation issues.