### PR TITLE
Here's the plan:

### DIFF
--- a/frontend/src/components/UseCaseForm.tsx
+++ b/frontend/src/components/UseCaseForm.tsx
@@ -145,7 +145,7 @@ const UseCaseForm: React.FC = () => {
         {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
         <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 3 }}>
           <Grid container spacing={3}>
-            <Grid item component="div" xs={12}>
+            <Grid xs={12}>
               <TextField
                 name="title"
                 label="Title"
@@ -156,7 +156,7 @@ const UseCaseForm: React.FC = () => {
                 disabled={isLoading}
               />
             </Grid>
-            <Grid item component="div" xs={12} sm={6}>
+            <Grid xs={12} sm={6}>
               <TextField
                 name="requestor"
                 label="Requestor"
@@ -167,7 +167,7 @@ const UseCaseForm: React.FC = () => {
                 disabled={isLoading}
               />
             </Grid>
-            <Grid item component="div" xs={12} sm={6}>
+            <Grid xs={12} sm={6}>
               <FormControl fullWidth required disabled={isLoading}>
                 <InputLabel id="stage-label">Stage</InputLabel>
                 <Select
@@ -184,7 +184,7 @@ const UseCaseForm: React.FC = () => {
                 </Select>
               </FormControl>
             </Grid>
-            <Grid item component="div" xs={12}>
+            <Grid xs={12}>
               <TextField
                 name="description"
                 label="Description"
@@ -197,7 +197,7 @@ const UseCaseForm: React.FC = () => {
                 disabled={isLoading}
               />
             </Grid>
-            <Grid item component="div" xs={12}>
+            <Grid xs={12}>
               <TextField
                 name="rationale"
                 label="Rationale"
@@ -210,7 +210,7 @@ const UseCaseForm: React.FC = () => {
                 disabled={isLoading}
               />
             </Grid>
-            <Grid item component="div" xs={12}>
+            <Grid xs={12}>
               <FormControl component="fieldset" disabled={isLoading}>
                 <FormLabel component="legend">Reviewed by AI Committee?</FormLabel>
                 <RadioGroup
@@ -228,7 +228,7 @@ const UseCaseForm: React.FC = () => {
 
             {isEditMode && (
               <>
-                <Grid item component="div" xs={12} sm={6}>
+                <Grid xs={12} sm={6}>
                   <DatePicker
                     label="Date Updated"
                     value={dateUpdated}
@@ -237,7 +237,7 @@ const UseCaseForm: React.FC = () => {
                     slotProps={{ textField: { fullWidth: true, disabled: true } }}
                   />
                 </Grid>
-                <Grid item component="div" xs={12} sm={6}>
+                <Grid xs={12} sm={6}>
                   <TextField
                     name="updated_by"
                     label="Updated By"
@@ -251,7 +251,7 @@ const UseCaseForm: React.FC = () => {
                 </Grid>
               </>
             )}
-            <Grid item component="div" xs={12}>
+            <Grid xs={12}>
               <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
                 <Button onClick={() => navigate('/')} sx={{ mr: 1 }} disabled={isLoading}>
                   Cancel


### PR DESCRIPTION
I'll attempt a workaround for persistent TypeScript errors (TS2769) related to the Material-UI Grid component in `frontend/src/components/UseCaseForm.tsx`.

The errors indicated that the `item` prop was not recognized as a valid prop on Grid components, even in standard usage patterns.

Here's what I'll do:
1. I'll ensure `component="div"` props (added in a previous attempt) are removed.
2. I'll remove the `item` boolean prop from all child Grid components within the main Grid container. The responsive props (e.g., `xs`, `sm`) will be retained.

This approach relies on the responsive props on direct children of a `Grid container` to implicitly define them as items, bypassing the problematic `item` prop for the type checker. This is a workaround due to unusual type checking behavior.